### PR TITLE
Fix TZ Permissions Issue & Suppress PyNaCl Warning

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -7,7 +7,7 @@ COPY src/ .
 COPY src/entrypoint.sh /entrypoint.sh
 
 RUN apk update && apk upgrade
-RUN apk add docker-cli python3 py3-pip tzdata
+RUN apk add docker-cli python3 py3-pip tzdata gosu
 
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
@@ -23,8 +23,6 @@ RUN addgroup -S -g 988 docker && \
     chmod 2775 /config && \
     chown -R nonroot:docker /src /entrypoint.sh && \
     chmod -R 755 /src /entrypoint.sh
-
-USER nonroot
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python3", "bot.py"]

--- a/src/bot.py
+++ b/src/bot.py
@@ -5,6 +5,9 @@ import scripts.settings as settings
 from discord import app_commands
 from discord.ext import commands
 
+# Suppress the PyNaCl warning since voice functionality isn't needed.
+discord.VoiceClient.warn_nacl = False
+
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(message)s',

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -11,4 +11,4 @@ else
     echo "No TZ environment variable set, using default"
 fi
 
-exec "$@"
+exec gosu nonroot "$@"


### PR DESCRIPTION
Fix timezone permission by moving permissions-drop to entrypoint.sh.

Suppress PyNaCl warning (not using voice) in bot.py